### PR TITLE
ReLogin

### DIFF
--- a/SpectatorPlugin/pom.xml
+++ b/SpectatorPlugin/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>de.cuzim1tigaaa.spectator</groupId>
         <artifactId>Spectator</artifactId>
-        <version>4.3</version>
+        <version>4.4</version>
     </parent>
 
     <artifactId>SpectatorPlugin</artifactId>
-    <version>4.3</version>
+    <version>4.4</version>
 
     <repositories>
         <repository>

--- a/SpectatorPlugin/src/main/java/de/cuzim1tigaaa/spectator/files/Messages.java
+++ b/SpectatorPlugin/src/main/java/de/cuzim1tigaaa/spectator/files/Messages.java
@@ -46,6 +46,7 @@ public class Messages {
             message = getMessage(player, path, replace);
             if(message == null) return;
             player.sendMessage(message);
+            return;
         }
 
         message = getMessage(sender, path, replace);

--- a/SpectatorPlugin/src/main/java/de/cuzim1tigaaa/spectator/listener/SpectatorListener.java
+++ b/SpectatorPlugin/src/main/java/de/cuzim1tigaaa/spectator/listener/SpectatorListener.java
@@ -52,6 +52,11 @@ public class SpectatorListener implements Listener {
 				this.sendUpdateNotification(player);
 		}
 
+		if(spectateUtils.getTeleportIfReLogin().containsKey(player.getUniqueId()))
+			Bukkit.getScheduler().runTaskLater(plugin, () -> player.teleport(
+					spectateUtils.getTeleportIfReLogin().remove(player.getUniqueId()),
+					PlayerTeleportEvent.TeleportCause.PLUGIN), 20L);
+
 		if(Config.getBoolean(Paths.CONFIG_HIDE_PLAYERS_TAB) && !hasPermission(player, BYPASS_TABLIST))
 			spectateAPI.getSpectators().forEach(spectator -> player.hidePlayer(plugin, spectator));
 
@@ -88,6 +93,7 @@ public class SpectatorListener implements Listener {
 		Player player = event.getPlayer();
 
 		if(spectateAPI.isSpectator(player)) {
+			Spectator.debug("Player " + player.getName() + " was spectating, unspectating...");
 			spectateUtils.unspectate(player, true);
 			return;
 		}

--- a/SpectatorPlugin/src/main/java/de/cuzim1tigaaa/spectator/spectate/SpectateUtilsGeneral.java
+++ b/SpectatorPlugin/src/main/java/de/cuzim1tigaaa/spectator/spectate/SpectateUtilsGeneral.java
@@ -22,6 +22,7 @@ public class SpectateUtilsGeneral {
 
 	private final Map<UUID, Location> spectateStartLocation = new HashMap<>();
 	private final Map<UUID, CycleTask> spectateCycle;
+	private final Map<UUID, Location> teleportIfReLogin = new HashMap<>();
 
 	public SpectateUtilsGeneral(SpectateAPI spectateAPI) {
 		this.plugin = spectateAPI.getPlugin();
@@ -129,7 +130,14 @@ public class SpectateUtilsGeneral {
 			info.restoreAttributes(true);
 
 		try {
-			Bukkit.getScheduler().runTask(plugin, () -> spectator.teleport(finalLocation, PlayerTeleportEvent.TeleportCause.PLUGIN));
+			Bukkit.getScheduler().runTask(plugin, () -> {
+				if(spectator.isOnline()) {
+					spectator.teleport(finalLocation, PlayerTeleportEvent.TeleportCause.PLUGIN);
+					return;
+				}
+				Spectator.debug("Could not teleport player, saving location for relogin");
+				this.teleportIfReLogin.put(spectator.getUniqueId(), finalLocation);
+			});
 		}catch(IllegalPluginAccessException e) {
 			// if unspectate is triggered by server shutting down
 			spectator.teleport(finalLocation, PlayerTeleportEvent.TeleportCause.PLUGIN);

--- a/SpectatorTest/pom.xml
+++ b/SpectatorTest/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>de.cuzim1tigaaa.spectator</groupId>
         <artifactId>Spectator</artifactId>
-        <version>4.3</version>
+        <version>4.4</version>
     </parent>
 
     <artifactId>SpectatorTest</artifactId>
-    <version>4.3</version>
+    <version>4.4</version>
 
     <repositories>
         <repository>
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>de.cuzim1tigaaa.spectator</groupId>
             <artifactId>SpectatorPlugin</artifactId>
-            <version>4.3</version>
+            <version>4.4</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.cuzim1tigaaa.spectator</groupId>
     <artifactId>Spectator</artifactId>
-    <version>4.3</version>
+    <version>4.4</version>
     <packaging>pom</packaging>
 
     <modules>


### PR DESCRIPTION
- missing return lead to duplicate messages if PAPI installed
- on re login, player gets teleported with short delay (20 ticks) to old location, if logged out in spectator mode  